### PR TITLE
EmbedPublicKey had a typo, and syntax error preventing keys from being embedded

### DIFF
--- a/ipns.go
+++ b/ipns.go
@@ -72,11 +72,11 @@ func EmbedPublicKey(pk ic.PubKey, entry *pb.IpnsEntry) error {
 	if err != nil {
 		return err
 	}
-	extraced, err := id.ExtractPublicKey()
+	extracted, err := id.ExtractPublicKey()
 	if err != nil {
 		return err
 	}
-	if extraced != nil {
+	if extracted == nil {
 		return nil
 	}
 	pkBytes, err := pk.Bytes()


### PR DESCRIPTION
When attempting to embed keys into IPNS records, the following check was performed
```
	extraced, err := id.ExtractPublicKey()
	if err != nil {
		return err
	}
	if extraced != nil {
		return nil
	}
```

`extraced` should be `extracted`

and `if extraced != nil` sould be `if extraced == nil` otherwise you will never be able to embed a PK into an IPNS entry. After making the change, I'm now able to successfully embed PKs into IPNS entries