### PR TITLE
Add usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ import (
 // however, you'll want to retrieve an already-existing key from IPFS using the
 // go-ipfs/core/coreapi CoreAPI.KeyAPI() interface.
 privateKey, publicKey, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
+if err != nil {
+  panic(err)
+}
 
 // Create an IPNS record that expires in one hour and points to the IPFS address
 // /ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5

--- a/README.md
+++ b/README.md
@@ -11,6 +11,35 @@
 This package contains all of components necessary to create, understand, and
 validate IPNS records.
 
+## Usage
+
+To create a new IPNS record:
+
+```go
+import (
+	"time"
+
+	ipns "github.com/ipfs/go-ipns"
+	crypto "github.com/libp2p/go-libp2p-crypto"
+)
+
+// Generate a private key to sign the IPNS record with. Most of the time, 
+// however, you'll want to retrieve an already-existing key from IPFS using the
+// go-ipfs/core/coreapi CoreAPI.KeyAPI() interface.
+privateKey, publicKey, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
+
+// Create an IPNS record that expires in one hour and points to the IPFS address
+// /ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5
+ipnsRecord, err := ipns.Create(privateKey, []byte("/ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5"), 0, time.Now().Add(1*time.Hour))
+if err != nil {
+	panic(err)
+}
+```
+
+Once you have the record, you’ll need to use IPFS to *publish* it.
+
+There are several other major operations you can do with `go-ipns`. Check out the [API docs](https://godoc.org/github.com/ipfs/go-ipns) or look at the tests in this repo for examples.
+
 ## Documentation
 
 https://godoc.org/github.com/ipfs/go-ipns

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@
 
 > ipns record definitions
 
-This package contains all of components necessary to create, understand, and
-validate IPNS records.
+This package contains all of components necessary to create, understand, and validate IPNS records. It does *not* publish or resolve those records. [`go-ipfs`](https://github.com/ipfs/go-ipfs) uses this package internally to manipulate records.
 
 ## Usage
 

--- a/ipns_test.go
+++ b/ipns_test.go
@@ -1,6 +1,7 @@
 package ipns
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -46,7 +47,10 @@ func ExampleCreate() {
 	// Generate a private key to sign the IPNS record with. Most of the time,
 	// however, you'll want to retrieve an already-existing key from IPFS using
 	// go-ipfs/core/coreapi CoreAPI.KeyAPI() interface.
-	privateKey, publicKey, err := ic.GenerateKeyPair(ic.RSA, 2048)
+	privateKey, _, err := ci.GenerateKeyPair(ci.RSA, 2048)
+	if err != nil {
+		panic(err)
+	}
 
 	// Create an IPNS record that expires in one hour and points to the IPFS address
 	// /ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5
@@ -54,4 +58,6 @@ func ExampleCreate() {
 	if err != nil {
 		panic(err)
 	}
+
+	fmt.Println(ipnsRecord)
 }

--- a/ipns_test.go
+++ b/ipns_test.go
@@ -41,3 +41,17 @@ func TestEmbedPublicKey(t *testing.T) {
 		t.Fatalf("pid mismatch: %s != %s", pid, embeddedPid)
 	}
 }
+
+func ExampleCreate() {
+	// Generate a private key to sign the IPNS record with. Most of the time,
+	// however, you'll want to retrieve an already-existing key from IPFS using
+	// go-ipfs/core/coreapi CoreAPI.KeyAPI() interface.
+	privateKey, publicKey, err := ic.GenerateKeyPair(ic.RSA, 2048)
+
+	// Create an IPNS record that expires in one hour and points to the IPFS address
+	// /ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5
+	ipnsRecord, err := Create(privateKey, []byte("/ipfs/Qme1knMqwt1hKZbc1BmQFmnm9f36nyQGwXxPGVpVJ9rMK5"), 0, time.Now().Add(1*time.Hour))
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This adds a usage section to the readme with an example for creating new records. There are probably more examples worth adding (validating? unmarshaling from bytes?), but this is a good start. I also duplicated the example for the godoc in the form of an example test.

Finally, I went ahead and added a small note to the top of the readme based on #1, clarifying what this package *doesn’t* do.

Fixes #9.