### PR TITLE
downgrade go-log

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
       "version": "1.2.8"
     },
     {
-      "hash": "QmcVVHfdyv15GVPk7NrxdWjh2hLVccXnoD8j2tyQShiXJb",
+      "hash": "Qmbi1CTJsbnBZjCEgc2otwu8cUFPsGpzWXG7edVCLZ7Gvk",
       "name": "go-log",
-      "version": "1.5.3"
+      "version": "1.5.2"
     },
     {
       "author": "whyrusleeping",


### PR DESCRIPTION
All of our other dependent packages use go log 1.5.2.