### PR TITLE
use new ExtractPublicKey signature

### DIFF
--- a/ipns.go
+++ b/ipns.go
@@ -73,12 +73,9 @@ func EmbedPublicKey(pk ic.PubKey, entry *pb.IpnsEntry) error {
 	if err != nil {
 		return err
 	}
-	extracted, err := id.ExtractPublicKey()
-	if err != nil {
+	if _, err := id.ExtractPublicKey(); err != peer.ErrNoPublicKey {
+		// Either a *real* error or nil.
 		return err
-	}
-	if extracted != nil {
-		return nil
 	}
 
 	// We failed to extract the public key from the peer ID, embed it in the

--- a/package.json
+++ b/package.json
@@ -26,20 +26,20 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmbNepETomvmXfz1X5pHNFD2QuPqnqi47dTd94QJWSorQ3",
+      "hash": "QmTRhk7cgjUf2gfQ3p2M9KPECNZEW9XUrmHcFCgog4cPgB",
       "name": "go-libp2p-peer",
-      "version": "2.3.8"
+      "version": "2.4.0"
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmWtCpWB39Rzc2xTB75MKorsxNpo3TyecTEN24CJ3KVohE",
+      "hash": "QmatE2nxsAaK96jxMFBPMtVJEsaMrcJ21UYBHpXTkEM95r",
       "name": "go-libp2p-peerstore",
-      "version": "2.0.4"
+      "version": "2.0.5"
     },
     {
-      "hash": "QmSb4B8ZAAj5ALe9LjfzPyF8Ma6ezC1NTnDF2JQPUJxEXb",
+      "hash": "Qma9Eqp16mNHDX1EL73pcxhFfzbyXVcAYtaDd1xdmDRDtL",
       "name": "go-libp2p-record",
-      "version": "4.1.7"
+      "version": "4.1.8"
     },
     {
       "author": "whyrusleeping",

--- a/record.go
+++ b/record.go
@@ -61,12 +61,12 @@ func (v Validator) Validate(key string, value []byte) error {
 }
 
 func (v Validator) getPublicKey(pid peer.ID, entry *pb.IpnsEntry) (ic.PubKey, error) {
-	pk, err := ExtractPublicKey(pid, entry)
-	if err != nil {
-		return nil, err
-	}
-	if pk != nil {
+	switch pk, err := ExtractPublicKey(pid, entry); err {
+	case peer.ErrNoPublicKey:
+	case nil:
 		return pk, nil
+	default:
+		return nil, err
 	}
 
 	if v.KeyBook == nil {


### PR DESCRIPTION
The new version returns an error if it fails to extract the public key, instead
of just `nil, nil`. This is significantly more "go-like" and less likely to
cause confusion.