### PR TITLE
testing: disable inline peer ID test

### DIFF
--- a/validate_test.go
+++ b/validate_test.go
@@ -128,6 +128,8 @@ func TestEmbeddedPubKeyValidate(t *testing.T) {
 }
 
 func TestPeerIDPubKeyValidate(t *testing.T) {
+	t.Skip("disabled until libp2p/go-libp2p-crypto#51 is fixed")
+
 	goodeol := time.Now().Add(time.Hour)
 	kbook := pstoremem.NewPeerstore()
 


### PR DESCRIPTION
We're disabling these until we can properly specify the hash function in the key
itself.